### PR TITLE
fix: UserId for compete profile is taken from token in headers

### DIFF
--- a/src/common/enums/error-message.enum.ts
+++ b/src/common/enums/error-message.enum.ts
@@ -16,4 +16,5 @@ export enum ErrorMessage {
   CertificatesNotFound = 'There is no certificates found',
   WorkExpNotFound = 'Work experiences not found',
   BacketNotFound = "Couldn't access AWS S3 bucket, check your credentials",
+  UserIsNotAuthorized = 'User not authorized or userId not found',
 }

--- a/src/modules/auth/types/user.request.type.ts
+++ b/src/modules/auth/types/user.request.type.ts
@@ -1,0 +1,7 @@
+import { Request } from 'express';
+
+export interface AuthenticatedRequest extends Request {
+  user?: {
+    id: string;
+  };
+}

--- a/src/modules/profile/enum/profile.enum.ts
+++ b/src/modules/profile/enum/profile.enum.ts
@@ -1,6 +1,6 @@
 export enum ProfileApiPath {
-  CaregiverProfile = '/:userId',
-  WorkExperience = '/work-experience/:userId',
-  Certificates = '/certificates/:userId',
-  UploadFile = '/uploadFile/:userId',
+  CaregiverProfile = '/',
+  WorkExperience = '/work-experience/',
+  Certificates = '/certificates/',
+  UploadFile = '/uploadFile/',
 }

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -4,7 +4,6 @@ import {
   Body,
   HttpStatus,
   Patch,
-  Param,
   Get,
   FileTypeValidator,
   MaxFileSizeValidator,
@@ -12,6 +11,8 @@ import {
   UploadedFile,
   UseInterceptors,
   UseGuards,
+  Req,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
@@ -28,6 +29,7 @@ import { WorkExperience } from 'src/common/entities/work-experience.entity';
 import { ApiPath } from 'src/common/enums/api-path.enum';
 import { ErrorMessage } from 'src/common/enums/error-message.enum';
 import { TokenGuard } from 'src/modules/auth/middleware/auth.middleware';
+import { AuthenticatedRequest } from 'src/modules/auth/types/user.request.type';
 import { ProfileApiPath } from 'src/modules/profile/enum/profile.enum';
 import { ProfileService } from 'src/modules/profile/profile.service';
 
@@ -87,8 +89,12 @@ export class ProfileController {
       }),
     )
     file: Express.Multer.File,
-    @Param('userId') userId: string,
+    @Req() request: AuthenticatedRequest,
   ): Promise<void> {
+    const userId = request.user.id;
+    if (!userId) {
+      throw new UnauthorizedException(ErrorMessage.UserIsNotAuthorized);
+    }
     await this.profileService.upload(file.originalname, file.buffer, userId);
   }
 
@@ -108,8 +114,13 @@ export class ProfileController {
     description: ErrorMessage.InternalServerError,
   })
   async getProfileInformation(
-    @Param('userId') userId: string,
+    @Req() request: AuthenticatedRequest,
   ): Promise<CaregiverInfo | undefined> {
+    const userId = request.user.id;
+    if (!userId) {
+      throw new UnauthorizedException(ErrorMessage.UserIsNotAuthorized);
+    }
+
     return this.profileService.getProfileInformation(userId);
   }
 
@@ -130,8 +141,13 @@ export class ProfileController {
     description: ErrorMessage.InternalServerError,
   })
   async getWorkExperiences(
-    @Param('userId') userId: string,
+    @Req() request: AuthenticatedRequest,
   ): Promise<WorkExperience[]> {
+    const userId = request.user.id;
+    if (!userId) {
+      throw new UnauthorizedException(ErrorMessage.UserIsNotAuthorized);
+    }
+
     return this.profileService.getWorkExperiences(userId);
   }
 
@@ -152,8 +168,13 @@ export class ProfileController {
     description: ErrorMessage.InternalServerError,
   })
   async getUserCertificates(
-    @Param('userId') userId: string,
+    @Req() request: AuthenticatedRequest,
   ): Promise<Certificate[]> {
+    const userId = request.user.id;
+    if (!userId) {
+      throw new UnauthorizedException(ErrorMessage.UserIsNotAuthorized);
+    }
+
     return this.profileService.getUserCertificates(userId);
   }
 
@@ -175,7 +196,11 @@ export class ProfileController {
     status: HttpStatus.INTERNAL_SERVER_ERROR,
     description: ErrorMessage.InternalServerError,
   })
-  async createProfile(@Param('userId') userId: string): Promise<void> {
+  async createProfile(@Req() request: AuthenticatedRequest): Promise<void> {
+    const userId = request.user.id;
+    if (!userId) {
+      throw new UnauthorizedException(ErrorMessage.UserIsNotAuthorized);
+    }
     await this.profileService.createProfile(userId);
   }
 
@@ -198,9 +223,14 @@ export class ProfileController {
     description: ErrorMessage.InternalServerError,
   })
   async updateProfile(
-    @Param('userId') userId: string,
+    @Req() request: AuthenticatedRequest,
     @Body() updateProfileDto: UpdateProfileDto,
   ): Promise<void> {
+    const userId = request.user.id;
+    if (!userId) {
+      throw new UnauthorizedException(ErrorMessage.UserIsNotAuthorized);
+    }
+
     await this.profileService.updateProfile(userId, updateProfileDto);
   }
 
@@ -222,9 +252,14 @@ export class ProfileController {
     description: ErrorMessage.InternalServerError,
   })
   addCertificate(
-    @Param('userId') userId: string,
+    @Req() request: AuthenticatedRequest,
     @Body() createCertificateDto: CreateCertificatesDto,
   ): Promise<Certificate[]> {
+    const userId = request.user.id;
+    if (!userId) {
+      throw new UnauthorizedException(ErrorMessage.UserIsNotAuthorized);
+    }
+
     return this.profileService.createCertificate(userId, createCertificateDto);
   }
 
@@ -246,9 +281,14 @@ export class ProfileController {
     description: ErrorMessage.InternalServerError,
   })
   addWorkExperience(
-    @Param('userId') userId: string,
+    @Req() request: AuthenticatedRequest,
     @Body() workExperienceDto: CreateWorkExperienceDto,
   ): Promise<WorkExperience[]> {
+    const userId = request.user.id;
+    if (!userId) {
+      throw new UnauthorizedException(ErrorMessage.UserIsNotAuthorized);
+    }
+
     return this.profileService.createWorkExperience(userId, workExperienceDto);
   }
 }

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -157,6 +157,7 @@ export class ProfileService {
   ): Promise<Certificate[]> {
     const caregiverInfo = await this.profileRepository
       .createQueryBuilder('profile')
+      .leftJoinAndSelect('profile.certificates', 'certificate')
       .where('profile.user = :userId', { userId })
       .getOne();
 
@@ -166,6 +167,8 @@ export class ProfileService {
         HttpStatus.NOT_FOUND,
       );
     }
+
+    await this.certificateRepository.remove(caregiverInfo.certificates);
 
     const certificates = await Promise.all(
       createCertificatesDto.certificates.map(async (certificateDto) => {
@@ -186,6 +189,7 @@ export class ProfileService {
   ): Promise<WorkExperience[]> {
     const caregiverInfo = await this.profileRepository
       .createQueryBuilder('profile')
+      .leftJoinAndSelect('profile.workExperiences', 'workExperience')
       .where('profile.user = :userId', { userId })
       .getOne();
 
@@ -195,6 +199,8 @@ export class ProfileService {
         HttpStatus.NOT_FOUND,
       );
     }
+
+    await this.workExperienceRepository.remove(caregiverInfo.workExperiences);
 
     const workExperiences = await Promise.all(
       createWorkExperienceDto.workExperiences.map(async (workExperienceDto) => {


### PR DESCRIPTION
## Describe your changes
- Redid endpoints of complete profile page(removed /:userId)
- Made restucture userId from token in headers
- Create certificate and create work_exp endpoints overwrite previous values (editing certificate info on frontend and here only saving and displaying values)

![Screenshot from 2023-11-30 12-54-15](https://github.com/ZenBit-Tech/ctrlchamps_be/assets/101258024/335f074f-5df0-4f1c-9eaa-ef5df01bca7f)

### **General**
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend
- [x] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] use @index decorator for frequently requested data