### PR TITLE
feat/fix: added status field to virtual_assessment to track if user accepted/rejected meeting

### DIFF
--- a/src/common/entities/virtual-assessment.entity.ts
+++ b/src/common/entities/virtual-assessment.entity.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 import { Appointment } from 'src/common/entities/appointment.entity';
+import { VirtualAssessmentStatus } from 'src/common/enums/virtual-assessment.enum';
 import {
   Entity,
   Column,
@@ -16,6 +17,18 @@ export class VirtualAssessment {
   })
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @ApiProperty({
+    description: 'Status of the virtual assessment',
+    enum: VirtualAssessmentStatus,
+    default: VirtualAssessmentStatus.Proposed,
+  })
+  @Column({
+    type: 'enum',
+    enum: VirtualAssessmentStatus,
+    default: VirtualAssessmentStatus.Proposed,
+  })
+  status: VirtualAssessmentStatus;
 
   @ApiProperty({
     description: 'Start time of the virtual assessment',

--- a/src/common/enums/virtual-assessment.enum.ts
+++ b/src/common/enums/virtual-assessment.enum.ts
@@ -1,0 +1,6 @@
+export enum VirtualAssessmentStatus {
+  Proposed = 'Proposed',
+  Accepted = 'Accepted',
+  Rejected = 'Rejected',
+  Finished = 'Finished',
+}

--- a/src/modules/virtual-assessment/constants/virtual-assessment.constant.ts
+++ b/src/modules/virtual-assessment/constants/virtual-assessment.constant.ts
@@ -2,6 +2,7 @@ export const VIRTUAL_ASSESSMENT_GET_EXAMPLE = {
   id: '78b96c71-a7cb-4598-966d-52c4b92d13cf',
   startTime: '03:00:00',
   endTime: '06:30:00',
+  status: 'Proposed',
   assessmentDate: '2023-12-31',
   meetingLink: 'https://meet.example.com/1234',
   appointment: {

--- a/src/modules/virtual-assessment/dto/update-status.dto.ts
+++ b/src/modules/virtual-assessment/dto/update-status.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { VirtualAssessmentStatus } from 'src/common/enums/virtual-assessment.enum';
+
+export class UpdateVirtualAssessmentStatusDto {
+  @ApiProperty({
+    description: 'Status of the virtual assessment',
+    enum: VirtualAssessmentStatus,
+  })
+  @IsEnum(VirtualAssessmentStatus)
+  @IsNotEmpty()
+  status: VirtualAssessmentStatus;
+}

--- a/src/modules/virtual-assessment/virtual-assessment.controller.ts
+++ b/src/modules/virtual-assessment/virtual-assessment.controller.ts
@@ -9,6 +9,7 @@ import {
   Req,
   UnauthorizedException,
   UseGuards,
+  Patch,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 
@@ -19,6 +20,7 @@ import { TokenGuard } from 'src/modules/auth/middleware/auth.middleware';
 import { AuthenticatedRequest } from 'src/modules/auth/types/user.request.type';
 
 import { VIRTUAL_ASSESSMENT_GET_EXAMPLE } from './constants/virtual-assessment.constant';
+import { UpdateVirtualAssessmentStatusDto } from './dto/update-status.dto';
 import { CreateVirtualAssessmentDto } from './dto/virtual-assessment.dto';
 import { VirtualAssessmentApiPath } from './enums/virtual-assessment-path.enum';
 import { VirtualAssessmentService } from './virtual-assessment.service';
@@ -107,5 +109,27 @@ export class VirtualAssessmentController {
     }
 
     return this.virtualAssessmentService.deleteVirtualAssessment(appointmentId);
+  }
+
+  @Patch(VirtualAssessmentApiPath.SingleVirtualAssessment)
+  @ApiOperation({
+    summary: 'Update status of a virtual assessment by appointment ID',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'The virtual assessment status has been updated successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: "The virtual assessment for this appontment wasn't found",
+  })
+  async updateStatus(
+    @Param('appointmentId') appointmentId: string,
+    @Body() updateStatusDto: UpdateVirtualAssessmentStatusDto,
+  ): Promise<void> {
+    return this.virtualAssessmentService.updateStatus(
+      appointmentId,
+      updateStatusDto,
+    );
   }
 }

--- a/src/modules/virtual-assessment/virtual-assessment.service.ts
+++ b/src/modules/virtual-assessment/virtual-assessment.service.ts
@@ -6,6 +6,7 @@ import { VirtualAssessment } from 'src/common/entities/virtual-assessment.entity
 import { ErrorMessage } from 'src/common/enums/error-message.enum';
 import { Repository } from 'typeorm';
 
+import { UpdateVirtualAssessmentStatusDto } from './dto/update-status.dto';
 import { CreateVirtualAssessmentDto } from './dto/virtual-assessment.dto';
 
 @Injectable()
@@ -48,7 +49,14 @@ export class VirtualAssessmentService {
 
       await this.virtualAssessmentRepository.save(virtualAssessment);
     } catch (error) {
-      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+      if (error instanceof HttpException) {
+        throw error;
+      } else {
+        throw new HttpException(
+          ErrorMessage.InternalServerError,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
     }
   }
 
@@ -71,7 +79,14 @@ export class VirtualAssessmentService {
 
       return virtualAssessment;
     } catch (error) {
-      throw new HttpException(error.message, HttpStatus.NOT_FOUND);
+      if (error instanceof HttpException) {
+        throw error;
+      } else {
+        throw new HttpException(
+          ErrorMessage.InternalServerError,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
     }
   }
 
@@ -82,7 +97,44 @@ export class VirtualAssessmentService {
 
       await this.virtualAssessmentRepository.remove(virtualAssessment);
     } catch (error) {
-      throw new HttpException(error.message, HttpStatus.NOT_FOUND);
+      if (error instanceof HttpException) {
+        throw error;
+      } else {
+        throw new HttpException(
+          ErrorMessage.InternalServerError,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+    }
+  }
+
+  async updateStatus(
+    appointmentId: string,
+    updateStatusDto: UpdateVirtualAssessmentStatusDto,
+  ): Promise<void> {
+    try {
+      const virtualAssessment =
+        await this.findVirtualAssessmentById(appointmentId);
+
+      if (!virtualAssessment) {
+        throw new HttpException(
+          ErrorMessage.VirtualAssessmentNotFound,
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      virtualAssessment.status = updateStatusDto.status;
+
+      await this.virtualAssessmentRepository.save(virtualAssessment);
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      } else {
+        throw new HttpException(
+          ErrorMessage.InternalServerError,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Describe your changes
- I added status column in virtual_assessment table and did endpoint to update status of virtual_assessment
- Small fix of error handling (now get 500 error when internal server error happens, not a 404)

![Screenshot from 2023-12-11 18-02-58](https://github.com/ZenBit-Tech/ctrlchamps_be/assets/101258024/3843320e-ebd6-4a69-851d-b28994539ffa)

![Screenshot from 2023-12-11 17-39-16](https://github.com/ZenBit-Tech/ctrlchamps_be/assets/101258024/88cd60e1-5d17-4653-b0e3-7afa993f71bf)
## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://homecareaid.atlassian.net/jira/software/projects/CC/boards/1?selectedIssue=CC-123)

### **General**
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend
- [x] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] use @index decorator for frequently requested data