### PR TITLE
fix: remove spread in activity log status dto

### DIFF
--- a/src/modules/activity-log/activity-log.service.ts
+++ b/src/modules/activity-log/activity-log.service.ts
@@ -43,7 +43,7 @@ export class ActivityLogService {
     try {
       await this.activityLogRepository.update(
         { id: activityLogId },
-        { ...updateActivityLogDto },
+        { status: updateActivityLogDto.status },
       );
     } catch (error) {
       throw new HttpException(


### PR DESCRIPTION
## Describe your changes
- Removed spread of dto because on review activity log seeker can reject appointment and specify reason that will be captured by this dto and throw error.

## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-151?atlOrigin=eyJpIjoiZGFkMWIyZGU0NzFlNGY5ZWJiMDcwNTJjODY5ZjBhY2MiLCJwIjoiaiJ9)

### **General**
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend
- [ ] Swagger documentation updated
- [ ] Database requests are optimized and not redundant
- [ ] Unit tests written
- [ ] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data