### PR TITLE
fix: now transactions returned in time desc order

### DIFF
--- a/src/common/entities/transaction-history.entity.ts
+++ b/src/common/entities/transaction-history.entity.ts
@@ -60,4 +60,11 @@ export class TransactionHistory {
   @ManyToOne(() => Appointment, (appointment) => appointment.transaction)
   @JoinColumn({ name: 'appointmentId' })
   appointment: Appointment;
+
+  @ApiProperty({
+    description: 'Date of transaction',
+    example: '2021-01-01 00:00:00',
+  })
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
 }

--- a/src/modules/payment/payment.service.ts
+++ b/src/modules/payment/payment.service.ts
@@ -375,6 +375,7 @@ export class PaymentService {
         .where('userId = :userId', {
           userId,
         })
+        .orderBy('transactions.createdAt', 'DESC')
         .getMany();
 
       return transactions;


### PR DESCRIPTION
## Describe your changes
- I did so that now the transactions are shown from the newest to the oldest.

## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-320)

### **General**
- [x] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).


### Backend
- [ ] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data