### PR TITLE
fix: move virtual assessment redirect to be first

### DIFF
--- a/src/modules/virtual-assessment/virtual-assessment.service.ts
+++ b/src/modules/virtual-assessment/virtual-assessment.service.ts
@@ -248,6 +248,8 @@ export class VirtualAssessmentService {
     res: Response,
   ): Promise<void> {
     try {
+      res.redirect(this.configService.get<string>('CORS_ORIGIN'));
+
       const virtualAssessment =
         await this.findVirtualAssessmentById(appointmentId);
 
@@ -270,8 +272,6 @@ export class VirtualAssessmentService {
       }
 
       await this.virtualAssessmentRepository.save(virtualAssessment);
-
-      res.redirect(this.configService.get<string>('CORS_ORIGIN'));
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;


### PR DESCRIPTION
## Describe your changes

- I moved redirect to the top of the service so that the user would be first redirected to the main page and after that was all the other logic connected to the status update.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-327)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [ ] Types for input and output parameters
- [ ] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [ ] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend

- [ ] Swagger documentation updated
- [ ] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data
