### PR TITLE
feat: add default seeker task module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { CaregiverInfo } from './common/entities/caregiver.profile.entity';
 import { Certificate } from './common/entities/certificate.entity';
+import { DefaultSeekerTask } from './common/entities/default-seeker-task.entity';
 import { Notification } from './common/entities/notification.entity';
 import { TransactionHistory } from './common/entities/transaction-history.entity';
 import { User } from './common/entities/user.entity';
@@ -40,6 +41,7 @@ import { EmailModule } from './modules/email/email.module';
 import { NotificationModule } from './modules/notification/notification.module';
 import { PaymentModule } from './modules/payment/payment.module';
 import { ProfileModule } from './modules/profile/profile.module';
+import { DefaultSeekerTaskModule } from './modules/seeker-task/default-seeker-task/default-seeker-task.module';
 import { UserModule } from './modules/users/user.module';
 import { VirtualAssessmentModule } from './modules/virtual-assessment/virtual-assessment.module';
 
@@ -70,6 +72,7 @@ import { VirtualAssessmentModule } from './modules/virtual-assessment/virtual-as
           SeekerCapability,
           SeekerDiagnosis,
           SeekerTask,
+          DefaultSeekerTask,
           VirtualAssessment,
           PaymentModule,
           ActivityLog,
@@ -99,6 +102,7 @@ import { VirtualAssessmentModule } from './modules/virtual-assessment/virtual-as
     PaymentModule,
     AdminPanelModule,
     NotificationModule,
+    DefaultSeekerTaskModule,
   ],
   controllers: [AppController],
   providers: [AppService, SeedingService],

--- a/src/common/entities/default-seeker-task.entity.ts
+++ b/src/common/entities/default-seeker-task.entity.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class DefaultSeekerTask {
+  @ApiProperty({
+    description: 'Default seeker task id',
+    example: '1e3a4c60-94aa-45de-aad0-7b4a49017b1f',
+  })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({
+    example: 'Assist with grocery shopping',
+    description: 'Name of the default seeker task',
+  })
+  @Column()
+  name: string;
+}

--- a/src/common/enums/api-path.enum.ts
+++ b/src/common/enums/api-path.enum.ts
@@ -11,4 +11,5 @@ export enum ApiPath {
   Transactions = 'transactions',
   Notifications = 'notifications',
   AdminPanel = 'admin-panel',
+  DefaultSeekerTask = 'default-seeker-task',
 }

--- a/src/common/enums/error-message.enum.ts
+++ b/src/common/enums/error-message.enum.ts
@@ -44,4 +44,8 @@ export enum ErrorMessage {
   SuperAdminDeleteForbidden = 'Super admin cannot be deleted',
   NotAdminRole = 'User role must be only Admin',
   UncompletedAppointmentDelete = 'Uncompleted appointment cannot be deleted',
+  FailedCreateDefaultSeekerTask = 'Failed to create default seeker task',
+  DefaultSeekerTaskNotFound = 'Default seeker task not found',
+  FailedUpdateDefaultSeekerTask = 'Failed to update default seeker task',
+  FailedDeleteDefaultSeekerTask = 'Failed to delete default seeker task',
 }

--- a/src/modules/seed/seed-data/tasks.seed.ts
+++ b/src/modules/seed/seed-data/tasks.seed.ts
@@ -1,0 +1,12 @@
+import { DefaultSeekerTask } from 'src/common/entities/default-seeker-task.entity';
+
+export const TASKS_SEED: Partial<DefaultSeekerTask>[] = [
+  { name: 'Monitoring and recording medication intake' },
+  { name: 'Supporting with exercises or physical therapy routines' },
+  { name: 'Assisting with transfers and mobility aids' },
+  { name: 'Ensuring a safe environment within the home' },
+  { name: 'Helping with meal planning and preparation' },
+  { name: 'Implementing safety measures within the home' },
+  { name: "Monitoring and reporting changes in the client's health" },
+  { name: 'Administering insulin injections' },
+];

--- a/src/modules/seed/seed.service.ts
+++ b/src/modules/seed/seed.service.ts
@@ -2,11 +2,13 @@ import { Injectable } from '@nestjs/common';
 
 import { Activity } from 'src/common/entities/activity.entity';
 import { Capability } from 'src/common/entities/capability.entity';
+import { DefaultSeekerTask } from 'src/common/entities/default-seeker-task.entity';
 import { Diagnosis } from 'src/common/entities/diagnosis.entity';
 import { User } from 'src/common/entities/user.entity';
 import { ACTIVITIES_SEED } from 'src/modules/seed/seed-data/activity.seed';
 import { CAPABILITIES_SEED } from 'src/modules/seed/seed-data/capability.seed';
 import { DIAGNOSES_SEED } from 'src/modules/seed/seed-data/diagnosis.seed';
+import { TASKS_SEED } from 'src/modules/seed/seed-data/tasks.seed';
 import { USERS_SEED } from 'src/modules/seed/seed-data/users.seed';
 import { DeepPartial, EntityManager, EntityTarget } from 'typeorm';
 
@@ -20,6 +22,7 @@ export class SeedingService {
       this.seedTable(Activity, ACTIVITIES_SEED),
       this.seedTable(Capability, CAPABILITIES_SEED),
       this.seedTable(User, USERS_SEED),
+      this.seedTable(DefaultSeekerTask, TASKS_SEED),
     ]);
   }
 

--- a/src/modules/seeker-task/default-seeker-task/default-seeker-task.constants.ts
+++ b/src/modules/seeker-task/default-seeker-task/default-seeker-task.constants.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_SEEKER_TASKS_EXAMPLE = [
+  {
+    data: [
+      {
+        id: '3849eadc-b0c1-11ee-b564-0250674f27f0',
+        name: 'Provide companionship and engage in conversation',
+      },
+      {
+        id: '3849ec24-b0c1-11ee-b564-0250674f27f0',
+        name: 'Assist with personal hygiene tasks',
+      },
+      {
+        id: '3849ec9d-b0c1-11ee-b564-0250674f27f0',
+        name: 'Monitor and record vital signs',
+      },
+    ],
+    count: 21,
+  },
+];
+
+export const DEFAULT_SEEKER_TASK_EXAMPLE = {
+  id: '3849eadc-b0c1-11ee-b564-0250674f27f0',
+  name: 'Provide companionship and engage in conversation',
+};
+
+export const PAGINATION_LIMIT = 10;

--- a/src/modules/seeker-task/default-seeker-task/default-seeker-task.controller.ts
+++ b/src/modules/seeker-task/default-seeker-task/default-seeker-task.controller.ts
@@ -1,0 +1,149 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { DefaultSeekerTask } from 'src/common/entities/default-seeker-task.entity';
+import { ApiPath } from 'src/common/enums/api-path.enum';
+import { ErrorMessage } from 'src/common/enums/error-message.enum';
+import { AllowedRoles } from 'src/decorators/roles-auth.decorator';
+import { TokenGuard } from 'src/modules/auth/middleware/auth.middleware';
+import { UserRole } from 'src/modules/users/enums/user-role.enum';
+
+import {
+  DEFAULT_SEEKER_TASKS_EXAMPLE,
+  DEFAULT_SEEKER_TASK_EXAMPLE,
+} from './default-seeker-task.constants';
+import { DefaultSeekerTaskService } from './default-seeker-task.service';
+import {
+  DefaultSeekerTaskQuery,
+  DefaultSeekerTaskResponse,
+} from './default-seeker-task.types';
+import { CreateDefaultSeekerTaskDto } from './dto/create-default-seeker-task.dto';
+import { UpdateDefaultSeekerTaskDto } from './dto/update-default-seeker-task.dto';
+import { DefaultSeekerTaskApiPath } from './enums/default-seeker-task.api-path.enum';
+
+@ApiTags('Default seeker task')
+@UseGuards(TokenGuard)
+@Controller(ApiPath.DefaultSeekerTask)
+export class DefaultSeekerTaskController {
+  constructor(
+    private readonly defaultSeekerTaskService: DefaultSeekerTaskService,
+  ) {}
+
+  @ApiOperation({ summary: 'Default seeker task creating' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Default seeker task was created successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: ErrorMessage.FailedCreateDefaultSeekerTask,
+  })
+  @Post(DefaultSeekerTaskApiPath.Root)
+  @AllowedRoles(UserRole.Admin, UserRole.SuperAdmin)
+  create(
+    @Body() createDefaultSeekerTaskDto: CreateDefaultSeekerTaskDto,
+  ): Promise<void> {
+    return this.defaultSeekerTaskService.create(
+      createDefaultSeekerTaskDto.name,
+    );
+  }
+
+  @ApiOperation({ summary: 'Getting all default seeker tasks' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Default seeker tasks were sent successfully',
+    schema: {
+      example: DEFAULT_SEEKER_TASKS_EXAMPLE,
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: ErrorMessage.InternalServerError,
+  })
+  @Get(DefaultSeekerTaskApiPath.Root)
+  findAll(
+    @Query() query: DefaultSeekerTaskQuery,
+  ): Promise<DefaultSeekerTaskResponse> {
+    return this.defaultSeekerTaskService.findAll(query);
+  }
+
+  @Get(DefaultSeekerTaskApiPath.Id)
+  @ApiOperation({ summary: 'Get one default seeker task' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Default seeker task info retrieved successfully',
+    schema: {
+      example: DEFAULT_SEEKER_TASK_EXAMPLE,
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: ErrorMessage.UserProfileNotFound,
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: ErrorMessage.InternalServerError,
+  })
+  findOne(@Param('id') id: string): Promise<DefaultSeekerTask> {
+    return this.defaultSeekerTaskService.findById(id);
+  }
+
+  @ApiOperation({ summary: 'Update default seeker task name' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Default seeker task name updated successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: ErrorMessage.FailedUpdateDefaultSeekerTask,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: ErrorMessage.DefaultSeekerTaskNotFound,
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: ErrorMessage.InternalServerError,
+  })
+  @Patch(DefaultSeekerTaskApiPath.Id)
+  @AllowedRoles(UserRole.Admin, UserRole.SuperAdmin)
+  update(
+    @Param('id') id: string,
+    @Body() updateDefaultSeekerTaskDto: UpdateDefaultSeekerTaskDto,
+  ): Promise<void> {
+    return this.defaultSeekerTaskService.update(
+      id,
+      updateDefaultSeekerTaskDto.name,
+    );
+  }
+
+  @ApiOperation({ summary: 'Delete default seeker task by id' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Default seeker task was deleted successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: ErrorMessage.DefaultSeekerTaskNotFound,
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: ErrorMessage.FailedDeleteDefaultSeekerTask,
+  })
+  @Delete(DefaultSeekerTaskApiPath.Id)
+  @AllowedRoles(UserRole.Admin, UserRole.SuperAdmin)
+  delete(@Param('id') id: string): Promise<void> {
+    return this.defaultSeekerTaskService.delete(id);
+  }
+}

--- a/src/modules/seeker-task/default-seeker-task/default-seeker-task.controller.ts
+++ b/src/modules/seeker-task/default-seeker-task/default-seeker-task.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { DefaultSeekerTask } from 'src/common/entities/default-seeker-task.entity';
 import { ApiPath } from 'src/common/enums/api-path.enum';
@@ -60,6 +60,24 @@ export class DefaultSeekerTaskController {
   }
 
   @ApiOperation({ summary: 'Getting all default seeker tasks' })
+  @ApiQuery({
+    name: 'limit',
+    description: 'Number of items per page',
+    type: Number,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'offset',
+    description: 'Number of items to skip',
+    type: Number,
+    required: false,
+  })
+  @ApiQuery({
+    name: 'search',
+    description: 'Search by efault seeker task name',
+    type: String,
+    required: false,
+  })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Default seeker tasks were sent successfully',

--- a/src/modules/seeker-task/default-seeker-task/default-seeker-task.module.ts
+++ b/src/modules/seeker-task/default-seeker-task/default-seeker-task.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { DefaultSeekerTask } from 'src/common/entities/default-seeker-task.entity';
+
+import { DefaultSeekerTaskController } from './default-seeker-task.controller';
+import { DefaultSeekerTaskService } from './default-seeker-task.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DefaultSeekerTask])],
+  controllers: [DefaultSeekerTaskController],
+  providers: [DefaultSeekerTaskService],
+})
+export class DefaultSeekerTaskModule {}

--- a/src/modules/seeker-task/default-seeker-task/default-seeker-task.service.ts
+++ b/src/modules/seeker-task/default-seeker-task/default-seeker-task.service.ts
@@ -1,0 +1,135 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { DefaultSeekerTask } from 'src/common/entities/default-seeker-task.entity';
+import { ErrorMessage } from 'src/common/enums/error-message.enum';
+import { Repository } from 'typeorm';
+
+import { PAGINATION_LIMIT } from './default-seeker-task.constants';
+import {
+  DefaultSeekerTaskQuery,
+  DefaultSeekerTaskResponse,
+} from './default-seeker-task.types';
+
+@Injectable()
+export class DefaultSeekerTaskService {
+  constructor(
+    @InjectRepository(DefaultSeekerTask)
+    private readonly defaultSeekerTaskRepository: Repository<DefaultSeekerTask>,
+  ) {}
+
+  async create(name: string): Promise<void> {
+    try {
+      await this.defaultSeekerTaskRepository
+        .createQueryBuilder()
+        .insert()
+        .into(DefaultSeekerTask)
+        .values({
+          name,
+        })
+        .execute();
+    } catch (error) {
+      throw new HttpException(
+        ErrorMessage.FailedCreateDefaultSeekerTask,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async findAll(
+    query: DefaultSeekerTaskQuery = {},
+  ): Promise<DefaultSeekerTaskResponse> {
+    try {
+      const limit = query.limit || PAGINATION_LIMIT;
+      const offset = query.offset || 0;
+      const search = query.search || '';
+
+      const [result, total] = await this.defaultSeekerTaskRepository
+        .createQueryBuilder('defaultSeekerTask')
+        .where(`(defaultSeekerTask.name LIKE :name )`, {
+          name: `%${search}%`,
+        })
+        .take(limit)
+        .skip(offset)
+        .getManyAndCount();
+
+      return {
+        data: result,
+        count: total,
+      };
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async findById(id: string): Promise<DefaultSeekerTask> {
+    try {
+      const defaultSeekerTask = await this.defaultSeekerTaskRepository
+        .createQueryBuilder('defaultSeekerTask')
+        .where('defaultSeekerTask.id = :id', {
+          id,
+        })
+        .getOne();
+
+      if (!defaultSeekerTask) {
+        throw new HttpException(
+          ErrorMessage.DefaultSeekerTaskNotFound,
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return defaultSeekerTask;
+    } catch (error) {
+      if (
+        error instanceof HttpException &&
+        error.getStatus() === HttpStatus.BAD_REQUEST
+      ) {
+        throw error;
+      }
+
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async update(id: string, name: string): Promise<void> {
+    try {
+      await this.findById(id);
+
+      await this.defaultSeekerTaskRepository
+        .createQueryBuilder()
+        .update(DefaultSeekerTask)
+        .set({ name })
+        .where('default_seeker_task.id = :id', {
+          id,
+        })
+        .execute();
+    } catch (error) {
+      throw new HttpException(
+        ErrorMessage.FailedUpdateDefaultSeekerTask,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      const defaultSeekerTask = await this.findById(id);
+
+      if (!defaultSeekerTask) {
+        throw new HttpException(
+          ErrorMessage.DefaultSeekerTaskNotFound,
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      await this.defaultSeekerTaskRepository
+        .createQueryBuilder()
+        .delete()
+        .from(DefaultSeekerTask)
+        .where('id = :id', { id })
+        .execute();
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/modules/seeker-task/default-seeker-task/default-seeker-task.types.ts
+++ b/src/modules/seeker-task/default-seeker-task/default-seeker-task.types.ts
@@ -1,0 +1,12 @@
+import { DefaultSeekerTask } from 'src/common/entities/default-seeker-task.entity';
+
+export type DefaultSeekerTaskQuery = {
+  limit?: number;
+  offset?: number;
+  search?: string;
+};
+
+export interface DefaultSeekerTaskResponse {
+  data: DefaultSeekerTask[];
+  count: number;
+}

--- a/src/modules/seeker-task/default-seeker-task/dto/create-default-seeker-task.dto.ts
+++ b/src/modules/seeker-task/default-seeker-task/dto/create-default-seeker-task.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+import { DefaultSeekerTaskValidationRule } from '../enums/default-seeker-task-create.validation-rule.enum';
+
+export class CreateDefaultSeekerTaskDto {
+  @ApiProperty({
+    description: "Default seeker task's name",
+    example: 'Go for a walk',
+  })
+  @MaxLength(DefaultSeekerTaskValidationRule.MaxLength)
+  @MinLength(DefaultSeekerTaskValidationRule.MinLength)
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+}

--- a/src/modules/seeker-task/default-seeker-task/dto/update-default-seeker-task.dto.ts
+++ b/src/modules/seeker-task/default-seeker-task/dto/update-default-seeker-task.dto.ts
@@ -1,0 +1,3 @@
+import { CreateDefaultSeekerTaskDto } from './create-default-seeker-task.dto';
+
+export class UpdateDefaultSeekerTaskDto extends CreateDefaultSeekerTaskDto {}

--- a/src/modules/seeker-task/default-seeker-task/enums/default-seeker-task-create.validation-rule.enum.ts
+++ b/src/modules/seeker-task/default-seeker-task/enums/default-seeker-task-create.validation-rule.enum.ts
@@ -1,0 +1,4 @@
+export enum DefaultSeekerTaskValidationRule {
+  MaxLength = 100,
+  MinLength = 5,
+}

--- a/src/modules/seeker-task/default-seeker-task/enums/default-seeker-task.api-path.enum.ts
+++ b/src/modules/seeker-task/default-seeker-task/enums/default-seeker-task.api-path.enum.ts
@@ -1,0 +1,4 @@
+export enum DefaultSeekerTaskApiPath {
+  Root = '',
+  Id = ':id',
+}


### PR DESCRIPTION
## Describe your changes
- Created default seeker task module.

![image](https://github.com/ZenBit-Tech/ctrlchamps_be/assets/61708790/df62ebf5-c2b8-40f9-982b-38c87c2deac7)

## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-238?atlOrigin=eyJpIjoiNTkyMmVlODAwN2Y2NGI2Njk1MTFhN2RlMTc4Mjg2MWUiLCJwIjoiaiJ9)


### **General**
- [x] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).


### Backend
- [x] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data