### PR TITLE
fix: Caregiver can't accept an expired VA request

### DIFF
--- a/src/common/enums/error-message.enum.ts
+++ b/src/common/enums/error-message.enum.ts
@@ -54,4 +54,5 @@ export enum ErrorMessage {
   FailedUpdateNotification = 'Failed to update notifications',
   UnreadNotificationsNotFound = 'Unread notifications not found',
   FailedFetchUnreadNotifications = 'Failed to fetch unread notifications',
+  AssessmentDate = 'Virtual assessment date has already passed',
 }

--- a/src/modules/cron/cron.service.ts
+++ b/src/modules/cron/cron.service.ts
@@ -191,11 +191,9 @@ export class CronService {
               appointment.id,
             );
 
-          const VADateString = virtualAssessment.assessmentDate.toString();
-
           if (
             virtualAssessment.status === VirtualAssessmentStatus.Proposed &&
-            currentDateString >= VADateString
+            currentDateString >= startDateString
           ) {
             await this.appointmentService.updateById(appointment.id, {
               status: AppointmentStatus.Rejected,

--- a/src/modules/cron/cron.service.ts
+++ b/src/modules/cron/cron.service.ts
@@ -185,6 +185,22 @@ export class CronService {
               status: AppointmentStatus.Ongoing,
             });
           }
+        } else if (appointment.status === AppointmentStatus.Virtual) {
+          const virtualAssessment =
+            await this.virtualAssessmentService.findVirtualAssessmentById(
+              appointment.id,
+            );
+
+          const VADateString = virtualAssessment.assessmentDate.toString();
+
+          if (
+            virtualAssessment.status === VirtualAssessmentStatus.Proposed &&
+            currentDateString >= VADateString
+          ) {
+            await this.appointmentService.updateById(appointment.id, {
+              status: AppointmentStatus.Rejected,
+            });
+          }
         }
       }),
     );

--- a/src/modules/virtual-assessment/virtual-assessment.service.ts
+++ b/src/modules/virtual-assessment/virtual-assessment.service.ts
@@ -189,6 +189,20 @@ export class VirtualAssessmentService {
         );
       }
 
+      const currentDate = utcToZonedTime(new Date(), UTC_TIMEZONE);
+      const currentDateString = currentDate.toString();
+      const VADateString = virtualAssessment.assessmentDate.toString();
+
+      if (
+        updateStatusDto.status === VirtualAssessmentStatus.Accepted &&
+        VADateString >= currentDateString
+      ) {
+        throw new HttpException(
+          ErrorMessage.AssessmentDate,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+
       virtualAssessment.status = updateStatusDto.status;
 
       await this.virtualAssessmentRepository.save(virtualAssessment);


### PR DESCRIPTION
## Describe your changes

- Caregiver can't accept an expired virtual assessment request.
- Added check to update VA status method - if VA date is expired user can not accept VA.
- Added check to cron - if VA status is Proposed and appointment start date is expired, change appointment status to Rejected.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-391)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend

- [x] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [ ] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data