### PR TITLE
fix: update appointment status to Rejected

### DIFF
--- a/src/modules/cron/cron.service.ts
+++ b/src/modules/cron/cron.service.ts
@@ -118,6 +118,10 @@ export class CronService {
         const currentDate = utcToZonedTime(new Date(), UTC_TIMEZONE);
         const currentDateString = currentDate.toString();
         const startDateString = appointment.startDate.toString();
+        const startDateUTC = utcToZonedTime(
+          appointment.startDate,
+          UTC_TIMEZONE,
+        );
 
         if (
           appointment.type === AppointmentType.OneTime &&
@@ -192,7 +196,7 @@ export class CronService {
 
           if (
             virtualAssessment.status === VirtualAssessmentStatus.Proposed &&
-            currentDateString >= startDateString
+            currentDate >= startDateUTC
           ) {
             await this.appointmentService.updateById(appointment.id, {
               status: AppointmentStatus.Rejected,

--- a/src/modules/virtual-assessment/virtual-assessment.service.ts
+++ b/src/modules/virtual-assessment/virtual-assessment.service.ts
@@ -189,12 +189,14 @@ export class VirtualAssessmentService {
       }
 
       const currentDate = utcToZonedTime(new Date(), UTC_TIMEZONE);
-      const currentDateString = currentDate.toString();
-      const VADateString = virtualAssessment.assessmentDate.toString();
+      const virtualAssessmentDate = utcToZonedTime(
+        `${virtualAssessment.assessmentDate} ${virtualAssessment.startTime}`,
+        UTC_TIMEZONE,
+      );
 
       if (
         updateStatusDto.status === VirtualAssessmentStatus.Accepted &&
-        VADateString >= currentDateString
+        virtualAssessmentDate >= currentDate
       ) {
         throw new HttpException(
           ErrorMessage.AssessmentDate,


### PR DESCRIPTION
## Describe your changes

- bug fix in updating appointment status to Rejected, when VA date has already passed

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-391)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend

- [x] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [ ] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data