### PR TITLE
fix: virtual assessment cron

### DIFF
--- a/src/common/enums/error-message.enum.ts
+++ b/src/common/enums/error-message.enum.ts
@@ -54,5 +54,5 @@ export enum ErrorMessage {
   FailedUpdateNotification = 'Failed to update notifications',
   UnreadNotificationsNotFound = 'Unread notifications not found',
   FailedFetchUnreadNotifications = 'Failed to fetch unread notifications',
-  AssessmentDate = 'Virtual assessment date has already passed',
+  AssessmentDate = 'Virtual assessment or appointment date has already passed',
 }

--- a/src/modules/cron/cron.service.ts
+++ b/src/modules/cron/cron.service.ts
@@ -188,20 +188,13 @@ export class CronService {
               status: AppointmentStatus.Ongoing,
             });
           }
-        } else if (appointment.status === AppointmentStatus.Virtual) {
-          const virtualAssessment =
-            await this.virtualAssessmentService.findVirtualAssessmentById(
-              appointment.id,
-            );
-
-          if (
-            virtualAssessment.status === VirtualAssessmentStatus.Proposed &&
-            currentDate >= startDateUTC
-          ) {
-            await this.appointmentService.updateById(appointment.id, {
-              status: AppointmentStatus.Rejected,
-            });
-          }
+        } else if (
+          appointment.status === AppointmentStatus.Virtual &&
+          currentDate >= startDateUTC
+        ) {
+          await this.appointmentService.updateById(appointment.id, {
+            status: AppointmentStatus.Rejected,
+          });
         }
       }),
     );

--- a/src/modules/virtual-assessment/virtual-assessment.service.ts
+++ b/src/modules/virtual-assessment/virtual-assessment.service.ts
@@ -193,10 +193,15 @@ export class VirtualAssessmentService {
         `${virtualAssessment.assessmentDate} ${virtualAssessment.startTime}`,
         UTC_TIMEZONE,
       );
+      const appointmentStartDate = utcToZonedTime(
+        virtualAssessment.appointment.startDate,
+        UTC_TIMEZONE,
+      );
 
       if (
         updateStatusDto.status === VirtualAssessmentStatus.Accepted &&
-        virtualAssessmentDate >= currentDate
+        (virtualAssessmentDate <= currentDate ||
+          virtualAssessmentDate >= appointmentStartDate)
       ) {
         throw new HttpException(
           ErrorMessage.AssessmentDate,


### PR DESCRIPTION
## Describe your changes

- Now if appointment has VA status (doesn't metter status of Virtual Assessment), and start date of appointment has already passed, appointment becomes Rejected

### **General**
- [x] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend
- [x] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data