### PR TITLE
fix: transactions for one hour

### DIFF
--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -30,6 +30,7 @@ import { UserService } from 'src/modules/users/user.service';
 import { Between, EntityManager, Repository } from 'typeorm';
 
 import { NotificationService } from '../notification/notification.service';
+import { TransactionType } from '../payment/enums/transaction-type.enum';
 import { PaymentService } from '../payment/payment.service';
 import { UserRole } from '../users/enums/user-role.enum';
 import { UTC_TIMEZONE } from '../virtual-assessment/constants/virtual-assessment.constant';
@@ -37,7 +38,6 @@ import { UTC_TIMEZONE } from '../virtual-assessment/constants/virtual-assessment
 import { AppointmentStatus } from './enums/appointment-status.enum';
 import { AppointmentType as TypeOfAppointment } from './enums/appointment-type.enum';
 import { SortOrder } from './enums/sort-query.enum';
-import { TransactionType } from '../payment/enums/transaction-type.enum';
 
 @Injectable()
 export class AppointmentService {

--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -37,6 +37,7 @@ import { UTC_TIMEZONE } from '../virtual-assessment/constants/virtual-assessment
 import { AppointmentStatus } from './enums/appointment-status.enum';
 import { AppointmentType as TypeOfAppointment } from './enums/appointment-type.enum';
 import { SortOrder } from './enums/sort-query.enum';
+import { TransactionType } from '../payment/enums/transaction-type.enum';
 
 @Injectable()
 export class AppointmentService {
@@ -207,12 +208,14 @@ export class AppointmentService {
               createAppointment.caregiverInfoId,
             );
 
-          await this.paymentService.createSeekerCaregiverTransactions(
-            userId,
-            caregiverInfo.user.id,
-            caregiverInfo.hourlyRate,
+          await this.paymentService.createTransaction(
+            {
+              userId,
+              type: TransactionType.Outcome,
+              amount: caregiverInfo.hourlyRate,
+              appointmentId,
+            },
             transactionalEntityManager,
-            appointmentId,
           );
 
           await this.sendAppointmentConfirmationEmails(


### PR DESCRIPTION
## Describe your changes

- now after creating appointment Client receives notification about 1 hour withdraw. Caregiver doesn’t receive notification.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-422)

### **General**
- [x] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend
- [ ] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data