### PR TITLE
feat: show correct appointment date when it has paused status

### DIFF
--- a/src/common/entities/appointment.entity.ts
+++ b/src/common/entities/appointment.entity.ts
@@ -188,6 +188,13 @@ export class Appointment {
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
   createdAt: Date;
 
+  @ApiProperty({
+    example: '2023-11-28T15:30:00.000Z',
+    description: 'Date when appointment was paused',
+  })
+  @Column({ type: 'timestamp', default: null, nullable: true })
+  pausedAt: Date;
+
   @OneToMany(
     () => SeekerDiagnosis,
     (seekerDiagnosis) => seekerDiagnosis.appointment,

--- a/src/common/helpers/is-appointment-date.helper.ts
+++ b/src/common/helpers/is-appointment-date.helper.ts
@@ -3,10 +3,17 @@ import { convertWeekdayToNumber } from 'src/common/helpers/convert-weekday-to-nu
 export const isAppointmentDate = (
   weekday: string,
   selectedDate: Date,
+  pausedAt: Date | null,
 ): boolean => {
   const weekdayNumbers = JSON.parse(weekday).map((day: string): number =>
     convertWeekdayToNumber(day),
   );
+
+  if (pausedAt) {
+    return (
+      pausedAt >= selectedDate && weekdayNumbers.includes(selectedDate.getDay())
+    );
+  }
 
   return weekdayNumbers.includes(selectedDate.getDay());
 };

--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -523,7 +523,11 @@ export class AppointmentService {
 
       const filteredAppointments = dateAppointments.filter((appointment) =>
         appointment.type === TypeOfAppointment.Recurring
-          ? isAppointmentDate(appointment.weekday, new Date(date))
+          ? isAppointmentDate(
+              appointment.weekday,
+              new Date(date),
+              appointment.pausedAt ? new Date(appointment.pausedAt) : null,
+            )
           : true,
       );
 

--- a/src/modules/payment/payment.service.ts
+++ b/src/modules/payment/payment.service.ts
@@ -827,7 +827,7 @@ export class PaymentService {
             ) {
               await this.appointmentService.updateByIdWithTransaction(
                 appointment.id,
-                { status: AppointmentStatus.Active },
+                { status: AppointmentStatus.Active, pausedAt: null },
                 transactionalEntityManager,
               );
 
@@ -869,6 +869,7 @@ export class PaymentService {
                 {
                   status: AppointmentStatus.Paused,
                   debtStatus: DebtStatus.NotAccrued,
+                  pausedAt: currentDate,
                 },
                 transactionalEntityManager,
               );


### PR DESCRIPTION
## Describe your changes
-  show correct appointment date when it has paused status.
## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-436?atlOrigin=eyJpIjoiYmQ1Y2QyODcxMjQzNDM1YmIxN2QyNmVhNGNmOGVjNDIiLCJwIjoiaiJ9)

### **General**
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend
- [ ] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [ ] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data